### PR TITLE
Add 'release' type (commitizen)

### DIFF
--- a/.cz-config.js
+++ b/.cz-config.js
@@ -64,6 +64,12 @@ module.exports = {
       value: 'perf',
       name: colorizeCommitType('perf: changes that improve performance'),
     },
+    {
+      value: 'release',
+      name: colorizeCommitType(
+        'release: version bumps, change log updates and release prep'
+      ),
+    },
   ],
   scopes: [...packageScopes, ...otherScopes],
   scopeOverrides: {
@@ -72,7 +78,8 @@ module.exports = {
     refactor: packageScopes,
     test: packageScopes,
     perf: packageScopes,
+    release: packageScopes,
   },
-  allowCustomScopes: true,
+  allowCustomScopes: false,
   allowBreakingChanges: ['feat', 'fix'],
 };

--- a/packages/icon-base/package.json
+++ b/packages/icon-base/package.json
@@ -16,7 +16,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/suitejs/suitejs/tree/master/packages/icon-base"
+    "url": "https://github.com/suitejs/suitejs.git"
   },
   "bugs": {
     "url": "https://github.com/suitejs/suitejs/issues"


### PR DESCRIPTION
### Description
Added a new type ('release') to `.cz-config.js`, to allow for commits concerned only with version changes, change log updates and other release-prep work.

Custom scopes have been disabled.

### Checklist

- [ ] I have covered any new additions with tests
- [x] I followed the [AngularJS Git Commit Message Conventions](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit)
- [x] I have [rebased unnecessary commits and rebased upstream changes from the parent branch](https://www.atlassian.com/git/tutorials/merging-vs-rebasing#workflow-walkthrough)
