### PR TITLE
Replace 'prepublish' hook with manual script

### DIFF
--- a/packages/icon-base/package-lock.json
+++ b/packages/icon-base/package-lock.json
@@ -1,6 +1,8 @@
 {
-	"requires": true,
+	"name": "@suitejs/icon-base",
+	"version": "0.0.0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"asap": {
 			"version": "2.0.6",

--- a/packages/icon-base/package.json
+++ b/packages/icon-base/package.json
@@ -30,10 +30,11 @@
     "build:es": "BABEL_ENV=es babel src/ --out-dir es/ --ignore spec.js",
     "clean": "rimraf es/ cjs/",
     "lint": "eslint src/ --cache --ext js,jsx",
-    "prepublish": "npm-run-all clean --parallel lint test build:*",
     "test": "jest --runInBand",
     "test:coverage": "jest --runInBand --coverage",
-    "test:watch": "jest --runInBand --watch"
+    "test:watch": "jest --runInBand --watch",
+    "prevalidate": "npm install",
+    "validate": "npm-run-all clean --parallel lint test build:*"
   },
   "dependencies": {
     "prop-types": "^15.5.7"


### PR DESCRIPTION
### Description

As this repository is developed in npm@5, the `prepublish` hook was being used to perform _pre-publish_ tasks (e.g. lint, test, transpile). However it will still be executed via `npm install` on older versions of NPM by a consumer of the package. This will cause the package installation to fail, as development dependencies/tasks are not intended to be downloaded/executed on 'install'.

There is a lot of confusion around this:
https://github.com/npm/npm/issues/16685
https://github.com/npm/npm/issues/15147

At the time of writing, there is no lifecycle hook available to perform a task _only_ prior to publishing, that is backwards compatible.

A manual `validate` script has been created to be used in it's place. This will lint, test, and transpile the package.

Any publishing activity will need to make sure this script is run across all packages before the `lerna publish` script is run. It should also be used in place of `lerna bootstrap`.

### Checklist

- [ ] I have covered any new additions with tests
- [x] I followed the [AngularJS Git Commit Message Conventions](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit)
- [x] I have [rebased unnecessary commits and rebased upstream changes from the parent branch](https://www.atlassian.com/git/tutorials/merging-vs-rebasing#workflow-walkthrough)
