### PR TITLE
Icon documentation fix

### DIFF
--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -33,13 +33,13 @@ All exports are named - you can refer to the [docs](docs) for the full listings 
 If you are using **CommonJS** modules, you can access them like so:
 
 ```js
-var SpFacebook = require('@suitejs/icons/sp/lib').SpFacebook;
+var SpFacebook = require('@suitejs/icons/lib/sp').SpFacebook;
 ```
 
 or, if your environment supports ES6 destructuring syntax:
 
 ```js
-var { SpFacebook, SpYouTube } = require('@suitejs/icons/sp/lib');
+var { SpFacebook, SpYouTube } = require('@suitejs/icons/lib/sp');
 ```
 
 `icons` uses [`icon-base`](https://github.com/suitejs/suitejs/tree/master/packages/icon-base) to set common settings. You can configure global settings for all your icons via React's context API. You can roll your own 'provider', or use the [`IconProvider`](https://github.com/suitejs/suitejs/tree/master/packages/icon-base#global-configuration) from the [`icon-base`](https://github.com/suitejs/suitejs/tree/master/packages/icon-base) package.


### PR DESCRIPTION
### Description

The documentation for the `@suitejs/icons` package had incorrect import statements for the commonjs module example.

### Checklist

- [ ] I have covered any new additions with tests
- [x] I followed the [AngularJS Git Commit Message Conventions](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit)
- [x] I have [rebased unnecessary commits and rebased upstream changes from the parent branch](https://www.atlassian.com/git/tutorials/merging-vs-rebasing#workflow-walkthrough)
